### PR TITLE
Updated VagrantFile with fix for windows

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "cmsirbu/ants"
 
   # private management network for devices to connect to (assign .1 to host machine)
-  config.vm.network 'private_network', ip: "10.250.0.11", netmask: 24, name: "vboxnet0"
+  # fixed network syntax for windows
+  config.vm.network 'private_network', ip: "10.250.0.11", netmask: "255.255.255.0"
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"


### PR DESCRIPTION
Changes:
1. Fixed syntax of netmask for private network.
2. Removed network adapter name as not Virtual Box friendly on Windows